### PR TITLE
add test for nil interface resolvers

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2,10 +2,12 @@ package graphql_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	graphqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/example/starwars"
 	"github.com/graph-gophers/graphql-go/gqltesting"
 )
@@ -241,6 +243,63 @@ func TestBasic(t *testing.T) {
 					}
 				}
 			`,
+		},
+	})
+}
+
+type testNilInterfaceResolver struct{}
+
+func (r *testNilInterfaceResolver) A() interface{ Z() int32 } {
+	return nil
+}
+
+func (r *testNilInterfaceResolver) B() (interface{ Z() int32 }, error) {
+	return nil, errors.New("x")
+}
+
+func (r *testNilInterfaceResolver) C() (interface{ Z() int32 }, error) {
+	return nil, nil
+}
+
+func TestNilInterface(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					a: T
+					b: T
+					c: T
+				}
+
+				type T {
+					z: Int!
+				}
+			`, &testNilInterfaceResolver{}),
+			Query: `
+				{
+					a { z }
+					b { z }
+					c { z }
+				}
+			`,
+			ExpectedResult: `
+				{
+					"a": null,
+					"b": null,
+					"c": null
+				}
+			`,
+			ExpectedErrors: []*graphqlerrors.QueryError{
+				&graphqlerrors.QueryError{
+					Message:       "x",
+					Path:          []interface{}{"b"},
+					ResolverError: errors.New("x"),
+				},
+			},
 		},
 	})
 }


### PR DESCRIPTION
Adds a test, as requested in https://github.com/graph-gophers/graphql-go/pull/239#issuecomment-414494652.

Prior to the fix, the new TestNilInterface test would fail with:

  graphql: panic occurred: reflect: Method on nil interface value

Now this test passes.